### PR TITLE
Fix for nmcli -t g error

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -8,7 +8,7 @@ export DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
 # ip route | grep default
 
 # 2. Is there Internet connectivity?
-# nmcli -t g | grep full
+# nmcli g | grep full
 
 # 3. Is there Internet connectivity via a google ping?
 # wget --spider http://google.com 2>&1


### PR DESCRIPTION
Error is "Option '--terse' requires specifying '--fields'"

It's also worth noting that using `nmcli` requires the installation of `network-manager`, however I doubt it's worth adding the dependency unless people want to use this command.