### PR TITLE
Point Raspbian installer regex to new repo org `balena-os`

### DIFF
--- a/scripts/raspbian-install.sh
+++ b/scripts/raspbian-install.sh
@@ -5,7 +5,7 @@ set -u
 trap "exit 1" TERM
 export TOP_PID=$$
 
-: "${WFC_REPO:=balena-io/wifi-connect}"
+: "${WFC_REPO:=balena-os/wifi-connect}"
 : "${WFC_INSTALL_ROOT:=/usr/local}"
 
 SCRIPT='raspbian-install.sh'


### PR DESCRIPTION
This is needed to fix the currently broken Raspbian install, which relies on knowing the location of the repository.

Fixes #389

Change-type: patch
Signed-off-by: Zahari Petkov <zahari@balena.io>