### PR TITLE
Use IW to scan for networks before launch

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,12 +1,24 @@
-FROM balenalib/%%BALENA_MACHINE_NAME%%-debian
+FROM debian:bullseye-slim
 
-RUN install_packages dnsmasq wireless-tools
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends \
+  ca-certificates \
+  dnsmasq \
+  iw \
+  wget \
+  wireless-tools && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/src/app
 
-ARG VERSION="4.4.0"
-RUN curl -Ls "https://github.com/balena-io/wifi-connect/releases/download/v$VERSION/wifi-connect-v$VERSION-linux-%%BALENA_ARCH%%.tar.gz" \
-  | tar -xvz -C  /usr/src/app/
+ARG WIFI_CONNECT_VERSION="v4.4.6"
+
+RUN wget -q -O wifi-connect.tar.gz "https://github.com/balena-os/wifi-connect/releases/download/${WIFI_CONNECT_VERSION}/wifi-connect-${WIFI_CONNECT_VERSION}-linux-%%BALENA_ARCH%%.tar.gz" && \
+  tar -xf wifi-connect.tar.gz && \
+  rm wifi-connect.tar.gz
 
 COPY scripts/start.sh .
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -25,6 +25,13 @@ iwgetid -r
 if [ $? -eq 0 ]; then
     printf 'Skipping WiFi Connect\n'
 else
+    # Fetch the name of the current WiFi interface, as they can be variable
+    wifi_interface_name=$(iw dev | awk '$1=="Interface"{print $2}')
+
+    # Update the list of available WiFi networks before launch
+    iw dev "$wifi_interface_name" scan &> /dev/null || printf 'Error updating WiFi network list with IW\n'
+
+    # Launch WiFi Connect
     printf 'Starting WiFi Connect\n'
     ./wifi-connect
 fi

--- a/ui/docker-compose.yml
+++ b/ui/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "2.1"
+
+services:
+  wifi-connect:
+    build: .
+    network_mode: "host"
+    labels:
+      io.balena.features.dbus: "1"
+    cap_add:
+      - NET_ADMIN
+    environment:
+      DBUS_SYSTEM_BUS_ADDRESS: "unix:path=/host/run/dbus/system_bus_socket"


### PR DESCRIPTION
- Reduces the likelihood of there being no WiFi networks visible in the WiFi selector dropdown menu
- Reduces the images size from 196mb to 80mb

Leaving here as a pull request and proof of concept. Will ask users with the issue to test and see the results before proposing a merge. 

Change-type: patch