### PR TITLE
Update the Dockerfile so that it will use a newer version, `4.11.1`.

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,12 +1,14 @@
 FROM balenalib/%%BALENA_MACHINE_NAME%%-debian
 
-RUN install_packages dnsmasq wireless-tools
+RUN install_packages dnsmasq wireless-tools unzip
 
 WORKDIR /usr/src/app
 
-ARG VERSION="4.4.0"
-RUN curl -Ls "https://github.com/balena-io/wifi-connect/releases/download/v$VERSION/wifi-connect-v$VERSION-linux-%%BALENA_ARCH%%.tar.gz" \
-  | tar -xvz -C  /usr/src/app/
+ARG VERSION="4.11.1"
+RUN curl -Ls -o /tmp/wifi-connect.zip \
+  "https://github.com/balena-io/wifi-connect/releases/download/v$VERSION/wifi-connect-v$VERSION-linux-%%BALENA_ARCH%%.zip" && \
+  unzip -o /tmp/wifi-connect.zip -d /usr/src/app && \
+  rm /tmp/wifi-connect.zip
 
 COPY scripts/start.sh .
 


### PR DESCRIPTION
#### Overview

I tried deploying `wifi-connect` on my own Balena fleet (Raspberry Pi 3), but got the the following errors when I'm using the files (`Dockerfile`, `docker-compose.yml`, and `scripts/start.sh`) out of the box.

```
15.03.23 13:49:50 (-0700)  wifi-connect  Starting WiFi Connect
15.03.23 13:49:50 (-0700)  wifi-connect  [network_manager::device:WARN] Undefined device type: 30
15.03.23 13:49:50 (-0700)  wifi-connect  Starting WiFi Connect
15.03.23 13:49:50 (-0700)  wifi-connect  [network_manager::device:WARN] Undefined device type: 30
15.03.23 13:49:50 (-0700)  wifi-connect  WiFi device: wlan0
15.03.23 13:49:50 (-0700)  wifi-connect  [network_manager::dbus_api:ERROR] Get org.freedesktop.NetworkManager.AccessPoint::RsnFlags property failed on /org/freedesktop/NetworkManager/AccessPoint/6: wrong property type
15.03.23 13:49:50 (-0700)  wifi-connect  Error: Getting access points failed
15.03.23 13:49:50 (-0700)  wifi-connect    caused by: D-Bus failure: Get org.freedesktop.NetworkManager.AccessPoint::RsnFlags property failed on /org/freedesktop/NetworkManager/AccessPoint/6: wrong property type
```

The version currently pinned in `Dockerfile.template` is 4.4.0.

After bumping the version to `4.11.1`, it seems that wifi-connect is working fine now (at least on my Pi 3 Model B+). Here's a sample console output.

```
screenly-anthias-wifi-connect-1  | Checking internet connectivity ...
screenly-anthias-wifi-connect-1  | Your device is not connected to the internet.
screenly-anthias-wifi-connect-1  | Starting up Wifi-Connect.
screenly-anthias-wifi-connect-1  | Connect to the Access Point and configure the SSID and Passphrase for the network to connect to.
screenly-anthias-wifi-connect-1  | [network_manager::device:WARN] Undefined device type: 30
screenly-anthias-wifi-connect-1  | WiFi device: wlan0
screenly-anthias-wifi-connect-1  | [network_manager::dbus_api:ERROR] Get org.freedesktop.NetworkManager.AccessPoint::RsnFlags property failed on /org/freedesktop/NetworkManager/AccessPoint/5313: wrong property type
screenly-anthias-wifi-connect-1  | Error: Getting access points failed
screenly-anthias-wifi-connect-1  |   caused by: D-Bus failure: Get org.freedesktop.NetworkManager.AccessPoint::RsnFlags property failed on /org/freedesktop/NetworkManager/AccessPoint/5313: wrong property type
```