### PR TITLE
WPA3 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,7 +407,7 @@ dependencies = [
 [[package]]
 name = "network-manager"
 version = "0.13.3"
-source = "git+https://github.com/balena-io-modules/network-manager.git#4da2e6a57de16b6ae911f74321f929d78af8b1ba"
+source = "git+https://github.com/hupster/network-manager.git#46e6c38034b4933ec73c5cb5d53220cb2de909b2"
 dependencies = [
  "ascii",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Zahari Petkov <zahari@balena.io>"]
 description = "Easy WiFi setup for Linux devices from your mobile phone or laptop"
 
 [dependencies]
-network-manager = { git = "https://github.com/balena-io-modules/network-manager.git" }
+network-manager = { git = "https://github.com/hupster/network-manager.git" }
 clap = "2.24"
 iron = "0.6"
 iron-cors = "0.8"

--- a/src/network.rs
+++ b/src/network.rs
@@ -280,6 +280,10 @@ fn init_access_point_credentials(
             identity: identity.to_string(),
             passphrase: passphrase.to_string(),
         }
+    } else if access_point.security.contains(Security::WPA3) {
+        AccessPointCredentials::Sae {
+            passphrase: passphrase.to_string(),
+        }
     } else if access_point.security.contains(Security::WPA2)
         || access_point.security.contains(Security::WPA)
     {
@@ -415,6 +419,8 @@ fn get_network_info(access_point: &AccessPoint) -> Network {
 fn get_network_security(access_point: &AccessPoint) -> &str {
     if access_point.security.contains(Security::ENTERPRISE) {
         "enterprise"
+    } else if access_point.security.contains(Security::WPA3) {
+        "wpa3"
     } else if access_point.security.contains(Security::WPA2)
         || access_point.security.contains(Security::WPA)
     {


### PR DESCRIPTION
This patch allows me to connect to WPA3 networks that use SAE authentication.

Relies on a patch on the network-manager plugin, so linking to my fork for now:
https://github.com/hupster/network-manager
https://github.com/balena-io-modules/network-manager/pull/146

I also have a branch merged with the patch for network refresh while connected from [meelash](https://github.com/meelash):
https://github.com/hupster/wifi-connect/tree/live_networks
https://github.com/balena-os/wifi-connect/pull/521

Without this, the error below shows while attempting to connect to a WPA3/SAE network.
```
Connecting to access point 'hupster'...
[<unknown>:ERROR] org.freedesktop.NetworkManager::AddAndActivateConnection method call failed on /org/freedesktop/NetworkManager
[wifi_connect::network:WARN] Error connecting to access point 'hupster': D-Bus failure: org.freedesktop.NetworkManager::AddAndActivateConnection method call failed on /org/freedesktop/NetworkManager
```
