### PR TITLE
Do not publish the repo to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "wifi-connect"
 version = "4.11.67"
 authors = ["Zahari Petkov <zahari@balena.io>"]
 description = "Easy WiFi setup for Linux devices from your mobile phone or laptop"
+publish = false
 
 [dependencies]
 network-manager = { git = "https://github.com/balena-io-modules/network-manager.git" }


### PR DESCRIPTION
The default is true. This prevents accidental publishing of the project

Change-type: patch