### PR TITLE
Enable builds for armv6 target

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -30,4 +30,5 @@ jobs:
         aarch64-unknown-linux-gnu,
         armv7-unknown-linux-gnueabihf,
         x86_64-unknown-linux-gnu,
-        i686-unknown-linux-gnu
+        i686-unknown-linux-gnu,
+        arm-unknown-linux-gnueabihf

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,10 @@ default-features = false
 
 [profile.release]
 lto = true
+
+[target.arm-unknown-linux-gnueabihf.env]
+passthrough = [
+    "RUSTFLAGS=-L /usr/arm-linux-gnueabihf/lib/ -L /usr/lib/arm-linux-gnueabihf/",
+    "PKG_CONFIG_PATH=/usr/lib/arm-linux-gnueabihf/pkgconfig/",
+    "PKG_CONFIG_ALLOW_CROSS=true"
+]

--- a/Cross.toml
+++ b/Cross.toml
@@ -3,3 +3,10 @@ pre-build = [
     "dpkg --add-architecture $CROSS_DEB_ARCH",
     "apt-get update && apt-get install --assume-yes libdbus-1-dev:$CROSS_DEB_ARCH"
 ]
+
+[target.arm-unknown-linux-gnueabihf.env]
+passthrough = [
+    "RUSTFLAGS=-L /usr/arm-linux-gnueabihf/lib/ -L /usr/lib/arm-linux-gnueabihf/",
+    "PKG_CONFIG_PATH=/usr/lib/arm-linux-gnueabihf/pkgconfig/",
+    "PKG_CONFIG_ALLOW_CROSS=true"
+]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -20,6 +20,8 @@ RUN \
             BINARY_ARCH_NAME="x86_64-unknown-linux-gnu" ;;\
         "armv7hf") \
             BINARY_ARCH_NAME="armv7-unknown-linux-gnueabihf" ;;\
+        "armv6") \
+            BINARY_ARCH_NAME="arm-unknown-linux-gnueabihf" ;;\
         *) \
             echo >&2 "error: unsupported architecture ($BALENA_ARCH)"; exit 1 ;; \ 
     esac;\


### PR DESCRIPTION
Related to #560

Enable builds for the armv6 target.

* **Cross.toml**: Add `arm-unknown-linux-gnueabihf` target with necessary environment variables for cross-compiling libdbus.
* **Cargo.toml**: Add environment variables for cross-compiling libdbus for the armv6 target under `[target.arm-unknown-linux-gnueabihf.env]`.
* **Dockerfile.template**: Add `arm-unknown-linux-gnueabihf` target for the armv6 architecture in the `case` statement.
* **.github/workflows/flowzone.yml**: Add `arm-unknown-linux-gnueabihf` target to the `cargo_targets` list.

