### PR TITLE
Update react-scripts

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -9,7 +9,7 @@
     "promise-polyfill": "^8.1.3",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-scripts": "^3.4.1",
+    "react-scripts": "^5.0.1",
     "rendition": "^18.3.0",
     "styled-components": "^5.0.1",
     "typescript": "^3.8.3",


### PR DESCRIPTION
the version of react scripts is outdated.  users are unable to run a dev server for the ui with the outdatded package.  this pr i update to 5.0.1 which is current version