### PR TITLE
Add missing dependencies in Dockerfile.template

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,6 +1,6 @@
 FROM debian:bullseye
 
-RUN apt-get update && apt-get install -y --no-install-recommends dnsmasq wireless-tools
+RUN apt-get update && apt-get install -y --no-install-recommends dnsmasq wireless-tools ca-certificates  curl
 
 # use latest version. If specific version is required, it should be provided as vX.Y.Z, e.g v4.11.37
 ARG VERSION="latest"


### PR DESCRIPTION
- Add `curl` and `ca-certificates` to the Dockerfile template

In my testing, the build failed without either one.